### PR TITLE
Add Data Field to Transaction (default = 0x)

### DIFF
--- a/app/multi-chain/page.tsx
+++ b/app/multi-chain/page.tsx
@@ -232,6 +232,7 @@ export default function Home() {
               placeholder="To Address"
             />
             <Input label="Value" {...register("value")} placeholder="Value" />
+            <Input label="Data" {...register("data")} placeholder="0x" />
             <Button type="submit" isLoading={isSendingTransaction}>
               Send Transaction
             </Button>

--- a/types/transaction.ts
+++ b/types/transaction.ts
@@ -1,4 +1,5 @@
 type Transaction = {
   to: string;
   value: string;
+  data?: string;
 };

--- a/utils/chain/EVM.tsx
+++ b/utils/chain/EVM.tsx
@@ -157,14 +157,14 @@ class EVM {
    * This method leverages the provided chain instance, transaction details, account credentials, and a specific derived path
    * to facilitate the execution of a transaction on the blockchain network.
    *
-   * @param {Transaction} data - Contains the transaction details such as the recipient's address and the transaction value.
+   * @param {Transaction} tx - Contains the transaction details such as the recipient's address and the transaction value.
    * @param {Account} account - Holds the account credentials including the unique account ID.
    * @param {string} keyPath - Specifies the key derivation path.
    * @param {string} derivationRootPublicKey - The root public key for derivation
    * @returns {Promise<void>} A promise that is fulfilled once the transaction has been successfully processed.
    */
   async handleTransaction(
-    data: Transaction,
+    tx: Transaction,
     account: Account,
     keyPath: string,
     derivationRootPublicKey: string
@@ -177,8 +177,9 @@ class EVM {
 
     const transaction = await this.attachGasAndNonce({
       from,
-      to: data.to,
-      value: parseEther(data.value),
+      to: tx.to,
+      value: parseEther(tx.value),
+      data: tx.data || "0x"
     });
 
     const transactionHash = EVM.prepareTransactionForSignature(transaction);


### PR DESCRIPTION
Adds a data field to the page (see near bottom of attached image):

This has been tested to be successfully signed and sent. See the following two sample transactions:

1. [Wrap ETH](https://sepolia.etherscan.io/tx/0x49c5b643ca57f755206658d085db56e85214dd19122afcaf659c5446f95c0e86)
2. [Unwrap ETH](https://sepolia.etherscan.io/tx/0x9631394b8da009cc0fde6efdb235675e25c60241f1142d45cb1f0d4b09666578)

To build the equivalent transactions for yourself you can use the following callData:

Wrap (aka Deposit): `0xd0e30db0` with `value > 0`

Unwrap (aka Withdraw) 1 WEI: 
`0x2e1a7d4d0000000000000000000000000000000000000000000000000000000000000001`


<img width="557" alt="Screenshot 2024-03-14 at 10 09 16" src="https://github.com/Pessina/near-sandbox/assets/11778116/becab30c-44c6-4b81-bb56-a5a111bcd1e9">